### PR TITLE
Fix ESLint config missing plugins

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,8 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import boundaries from "eslint-plugin-boundaries";
+import next from "@next/eslint-plugin-next";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
## Summary
- load eslint-plugin-boundaries and @next/eslint-plugin-next in config

## Testing
- `npm run lint` *(fails: no-unused-vars and explicit-any errors)*