### PR TITLE
Resolve ESLint warnings

### DIFF
--- a/src/app/api/exercises/[slug]/run-tests/route.ts
+++ b/src/app/api/exercises/[slug]/run-tests/route.ts
@@ -70,7 +70,7 @@ export async function POST(
     jail.setSync(
       "myLog",
       new ivm.Callback(
-        (...args: any[]) => console.log("[Isolate log]", ...args),
+        (...args: unknown[]) => console.log("[Isolate log]", ...args),
         { sync: true }
       )
     );
@@ -157,7 +157,11 @@ try {
     }
 
     // copySync() to get a plain JS object in Node
-    const rawResult = resultRef.copySync() as { success: boolean; results?: any; error?: string };
+    const rawResult = resultRef.copySync() as {
+      success: boolean;
+      results?: TestResult[];
+      error?: string;
+    };
 
     if (!rawResult.success) {
       return NextResponse.json(

--- a/src/app/exercises/[slug]/not-found.tsx
+++ b/src/app/exercises/[slug]/not-found.tsx
@@ -9,7 +9,7 @@ export default function NotFound() {
           <CardTitle>Exercise Not Found</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="mb-4">Sorry, the exercise you're looking for doesn't exist.</p>
+          <p className="mb-4">Sorry, the exercise you&apos;re looking for doesn&apos;t exist.</p>
           <Link 
             href="/exercises" 
             className="text-primary hover:underline"

--- a/src/app/exercises/[slug]/page.tsx
+++ b/src/app/exercises/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
-import { Metadata, ResolvingMetadata } from "next";
+import { Metadata } from "next";
 import { EXERCISES } from "@/features/codingChallenges/data/exercisesData";
-import { ExerciseClient } from "@/app/exercises/[slug]/ExerciseClient";
+import { ExerciseClient } from "@/features/codingChallenges/components/ExerciseClient";
 
 type Props = {
   params: {
@@ -11,8 +11,7 @@ type Props = {
 
 // Generate metadata for each exercise page
 export async function generateMetadata(
-  { params }: Props,
-  parent: ResolvingMetadata
+  { params }: Props
 ): Promise<Metadata> {
   const { slug } = await params;
   const exercise = EXERCISES.find((ex) => ex.slug === slug);

--- a/src/app/exercises/page.tsx
+++ b/src/app/exercises/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import React, { useState, ChangeEvent, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { EXERCISES, CATEGORY_METHODS } from "@/features/codingChallenges/data/exercisesData";
 import { ExerciseCard } from "@/features/codingChallenges/components/ExerciseCard";
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { motion, AnimatePresence } from "framer-motion";
-import { Search, Code2, BookOpen, Layers, Trophy, ChevronDown } from "lucide-react";
+import { Search, Code2, BookOpen, Layers, Trophy } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useDebounce } from "@/hooks/useDebounce";
 import {
@@ -64,7 +63,7 @@ export default function ExercisesPage() {
   const methodsWithCategories = selectedCategory === "all"
     ? Array.from(new Set(Object.values(CATEGORY_METHODS).flat())).map(method => {
         const categories = Object.entries(CATEGORY_METHODS)
-          .filter(([_, methods]) => (methods as readonly string[]).includes(method as string))
+          .filter(([, methods]) => (methods as readonly string[]).includes(method as string))
           .map(([category]) => category);
         return { method, categories };
       })
@@ -326,7 +325,7 @@ export default function ExercisesPage() {
                         <h3 className="text-xl font-semibold">No exercises found</h3>
                         <p className="text-muted-foreground max-w-[350px] mx-auto">
                           {searchQuery ? (
-                            <>No exercises match your search "{searchQuery}". Try different keywords or clear your search.</>
+                            <>No exercises match your search &quot;{searchQuery}&quot;. Try different keywords or clear your search.</>
                           ) : selectedCategory !== "all" || selectedMethod !== "all" ? (
                             <>No exercises found with the selected filters. Try adjusting your category or method selection.</>
                           ) : (

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -17,11 +17,10 @@ export function Markdown({ content, className, sanitize = true, ...props }: Mark
   return (
     <div className={cn("prose prose-sm dark:prose-invert max-w-none", className)} {...props}>
       <ReactMarkdown
-        children={content}
         remarkPlugins={[remarkGfm]}
         rehypePlugins={sanitize ? [rehypeSanitize] : []}
         components={{
-          code({ node, inline, className, children, ...props }) {
+          code({ inline, className, children, ...props }) {
             const match = /language-(\w+)/.exec(className || "");
             return !inline && match ? (
               <SyntaxHighlighter
@@ -81,7 +80,9 @@ export function Markdown({ content, className, sanitize = true, ...props }: Mark
             return <h4 className="scroll-m-20 text-xl font-semibold tracking-tight">{children}</h4>;
           },
         }}
-      />
+      >
+        {content}
+      </ReactMarkdown>
     </div>
   );
 } 

--- a/src/features/codingChallenges/components/CodeEditor.tsx
+++ b/src/features/codingChallenges/components/CodeEditor.tsx
@@ -34,12 +34,12 @@ export type CodeEditorHandle = {
   runTests: () => Promise<void>;
 };
 
-const getStorageValue = (key: string, defaultValue: any) => {
+const getStorageValue = <T,>(key: string, defaultValue: T): T => {
   if (typeof window === "undefined") return defaultValue;
   try {
     const saved = localStorage.getItem(key);
-    return saved ? saved : defaultValue;
-  } catch (err) {
+    return (saved as unknown as T) ?? defaultValue;
+  } catch {
     return defaultValue;
   }
 };
@@ -55,7 +55,6 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [testResults, setTestResults] = useState<TestResult[]>([]);
   const [language, setLanguage] = useState<"typescript" | "javascript">(defaultLanguage);
   const isInitialMount = useRef(true);
 
@@ -102,7 +101,6 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     try {
       setIsSubmitting(true);
       setError(null);
-      setTestResults([]);
 
       const code = editorRef.current.getValue();
 
@@ -122,7 +120,6 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
       }
 
       const { results: newResults } = await response.json();
-      setTestResults(newResults);
       onTestResults?.(newResults);
     } catch (err) {
       setError(
@@ -158,7 +155,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     );
   }, [handleRunTests, slug]);
 
-  const handleEditorValidation = useCallback((markers: any[]) => {
+  const handleEditorValidation = useCallback((markers: unknown[]) => {
     // Log validation issues for debugging
     markers.forEach((marker) => {
       console.log("onValidate:", marker.message);

--- a/src/features/codingChallenges/components/ExerciseClient.tsx
+++ b/src/features/codingChallenges/components/ExerciseClient.tsx
@@ -48,30 +48,10 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Markdown } from "@/components/ui/markdown";
-
-type Exercise = {
-  slug: string;
-  title: string;
-  description: string;
-  category: {
-    name: string;
-    method: string;
-  };
-  education: {
-    concept: string;
-    explanation: string;
-    useCases: string[];
-    visualExample?: string;
-    commonMistakes?: string[];
-    tips?: string[];
-  };
-  starterCode: string;
-  testCases: Array<{
-    input: any;
-    expected: any;
-    message: string;
-  }>;
-};
+import type {
+  Exercise,
+  TestCase,
+} from "@/features/codingChallenges/data/exercisesData";
 
 type Props = {
   exercise: Exercise;
@@ -85,12 +65,12 @@ const KEYBOARD_SHORTCUTS = [
   { key: "Esc", description: "Exit Fullscreen" },
 ];
 
-const getStorageValue = (key: string, defaultValue: any) => {
+const getStorageValue = <T,>(key: string, defaultValue: T): T => {
   if (typeof window === "undefined") return defaultValue;
   try {
     const saved = localStorage.getItem(key);
-    return saved ? saved : defaultValue;
-  } catch (err) {
+    return (saved as unknown as T) ?? defaultValue;
+  } catch {
     return defaultValue;
   }
 };
@@ -175,11 +155,11 @@ export function ExerciseClient({ exercise }: Props) {
               </Button>
             </Link>
             <Separator orientation="vertical" className="h-6" />
-            <a className="flex items-center space-x-2" href="/">
+            <Link href="/" className="flex items-center space-x-2">
               <span className="hidden font-bold sm:inline-block">
                 JavaScript Methods Learning
               </span>
-            </a>
+            </Link>
           </div>
           <div className="flex items-center gap-2">
             <Dialog>
@@ -488,7 +468,7 @@ export function ExerciseClient({ exercise }: Props) {
 }
 
 type TestCaseAccordionProps = {
-  test: any;
+  test: TestCase;
   index: number;
   result?: TestResult;
 };


### PR DESCRIPTION
## Summary
- move ExerciseClient to features folder to satisfy boundaries
- escape quotes in not-found and exercises page
- remove unused imports and variables
- fix `any` usages and unused catch params
- prefer type aliases and generics
- adjust Markdown component children handling

## Testing
- `npm run lint`