### PR TITLE
Simplify component debug attributes

### DIFF
--- a/src/app/exercises/[slug]/not-found.tsx
+++ b/src/app/exercises/[slug]/not-found.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function NotFound() {
   return (
-    <div className="container mx-auto py-8 px-4">
+    <div data-component="ExerciseNotFound" className="container mx-auto py-8 px-4">
       <Card>
         <CardHeader>
           <CardTitle>Exercise Not Found</CardTitle>

--- a/src/app/exercises/layout.tsx
+++ b/src/app/exercises/layout.tsx
@@ -11,7 +11,7 @@ export default function ExercisesLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="min-h-screen bg-background">
+    <div data-component="ExercisesLayout" className="min-h-screen bg-background">
       <main className="container mx-auto py-8 px-4">
         {children}
       </main>

--- a/src/app/exercises/page.tsx
+++ b/src/app/exercises/page.tsx
@@ -80,7 +80,8 @@ export default function ExercisesPage() {
   };
 
   return (
-    <motion.div 
+    <motion.div
+      data-component="ExercisesPage"
       variants={containerVariants}
       initial="hidden"
       animate="visible"
@@ -392,7 +393,8 @@ function StatsCard({ icon, value, label, highlight = false }: {
   highlight?: boolean;
 }) {
   return (
-    <motion.div 
+    <motion.div
+      data-component="StatsCard"
       whileHover={{ scale: 1.05 }}
       className={cn(
         "rounded-lg p-4 text-center space-y-2 bg-card border shadow-sm",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        data-component="RootLayout"
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,10 @@ import Image from "next/image";
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+    <div
+      data-component="HomePage"
+      className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]"
+    >
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <Image
           className="dark:invert"

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -29,7 +29,11 @@ export interface BadgeProps
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+    <div
+      data-component="Badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
   )
 }
 Badge.displayName = "Badge"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -44,6 +44,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : "button";
     return (
       <Comp
+        data-component="Button"
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,6 +7,7 @@ const Card = React.forwardRef<
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div
+    data-component="Card"
     ref={ref}
     className={cn(
       "rounded-lg border bg-card text-card-foreground shadow-sm",
@@ -22,6 +23,7 @@ const CardHeader = React.forwardRef<
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div
+    data-component="CardHeader"
     ref={ref}
     className={cn("flex flex-col space-y-1.5 p-6", className)}
     {...props}
@@ -34,6 +36,7 @@ const CardTitle = React.forwardRef<
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <h3
+    data-component="CardTitle"
     ref={ref}
     className={cn(
       "text-lg font-semibold leading-none tracking-tight",
@@ -49,6 +52,7 @@ const CardDescription = React.forwardRef<
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
   <p
+    data-component="CardDescription"
     ref={ref}
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
@@ -60,7 +64,12 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div
+    data-component="CardContent"
+    ref={ref}
+    className={cn("p-6 pt-0", className)}
+    {...props}
+  />
 ))
 CardContent.displayName = "CardContent"
 
@@ -69,6 +78,7 @@ const CardFooter = React.forwardRef<
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div
+    data-component="CardFooter"
     ref={ref}
     className={cn(" flex items-center p-6 pt-0", className)}
     {...props}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -13,6 +13,7 @@ const Command = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive
+    data-component="Command"
     ref={ref}
     className={cn(
       "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
@@ -25,7 +26,7 @@ Command.displayName = CommandPrimitive.displayName
 
 const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
-    <Dialog {...props}>
+    <Dialog data-component="CommandDialog" {...props}>
       <DialogContent className="overflow-hidden p-0">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
@@ -39,9 +40,10 @@ const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+  <div data-component="CommandInputWrapper" className="flex items-center border-b px-3" cmdk-input-wrapper="">
     <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
     <CommandPrimitive.Input
+      data-component="CommandInput"
       ref={ref}
       className={cn(
         "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
@@ -59,6 +61,7 @@ const CommandList = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
+    data-component="CommandList"
     ref={ref}
     className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
     {...props}
@@ -72,6 +75,7 @@ const CommandEmpty = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
 >((props, ref) => (
   <CommandPrimitive.Empty
+    data-component="CommandEmpty"
     ref={ref}
     className="py-6 text-center text-sm"
     {...props}
@@ -85,6 +89,7 @@ const CommandGroup = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Group
+    data-component="CommandGroup"
     ref={ref}
     className={cn(
       "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
@@ -101,6 +106,7 @@ const CommandSeparator = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Separator
+    data-component="CommandSeparator"
     ref={ref}
     className={cn("-mx-1 h-px bg-border", className)}
     {...props}
@@ -113,6 +119,7 @@ const CommandItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Item
+    data-component="CommandItem"
     ref={ref}
     className={cn(
       "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -130,6 +137,7 @@ const CommandShortcut = ({
 }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
+      data-component="CommandShortcut"
       className={cn(
         "ml-auto text-xs tracking-widest text-muted-foreground",
         className

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -19,6 +19,7 @@ const DialogOverlay = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
+    data-component="DialogOverlay"
     ref={ref}
     className={cn(
       "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
@@ -36,6 +37,7 @@ const DialogContent = React.forwardRef<
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
+      data-component="DialogContent"
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,6 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
     return (
       <input
+        data-component="Input"
         type={type}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -32,7 +32,11 @@ const renderCodeBlock = (
 
 export function Markdown({ content, className, sanitize = true, ...props }: MarkdownProps) {
   return (
-    <div className={cn("prose prose-sm dark:prose-invert max-w-none", className)} {...props}>
+    <div
+      data-component="Markdown"
+      className={cn("prose prose-sm dark:prose-invert max-w-none", className)}
+      {...props}
+    >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={sanitize ? [rehypeSanitize] : []}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,6 +17,7 @@ const SelectTrigger = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
+    data-component="SelectTrigger"
     ref={ref}
     className={cn(
       "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
@@ -37,6 +38,7 @@ const SelectScrollUpButton = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollUpButton
+    data-component="SelectScrollUpButton"
     ref={ref}
     className={cn(
       "flex cursor-default items-center justify-center py-1",
@@ -54,6 +56,7 @@ const SelectScrollDownButton = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollDownButton
+    data-component="SelectScrollDownButton"
     ref={ref}
     className={cn(
       "flex cursor-default items-center justify-center py-1",
@@ -73,6 +76,7 @@ const SelectContent = React.forwardRef<
 >(({ className, children, position = "popper", ...props }, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
+      data-component="SelectContent"
       ref={ref}
       className={cn(
         "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
@@ -116,6 +120,7 @@ const SelectItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Item
+    data-component="SelectItem"
     ref={ref}
     className={cn(
       "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -14,6 +14,7 @@ const Separator = React.forwardRef<
     ref
   ) => (
     <SeparatorPrimitive.Root
+      data-component="Separator"
       ref={ref}
       decorative={decorative}
       orientation={orientation}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -6,6 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
+      data-component="Skeleton"
       className={cn("animate-pulse rounded-md bg-primary/10", className)}
       {...props}
     />

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,6 +12,7 @@ const TabsList = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.List
+    data-component="TabsList"
     ref={ref}
     className={cn(
       "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
@@ -27,6 +28,7 @@ const TabsTrigger = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Trigger
+    data-component="TabsTrigger"
     ref={ref}
     className={cn(
       "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
@@ -42,6 +44,7 @@ const TabsContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Content
+    data-component="TabsContent"
     ref={ref}
     className={cn(
       "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -16,6 +16,7 @@ const TooltipContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
   <TooltipPrimitive.Content
+    data-component="TooltipContent"
     ref={ref}
     sideOffset={sideOffset}
     className={cn(

--- a/src/features/codingChallenges/components/CodeEditor.tsx
+++ b/src/features/codingChallenges/components/CodeEditor.tsx
@@ -184,6 +184,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
 
   return (
     <Card
+      data-component="CodeEditor"
       className={cn("flex flex-col flex-grow min-h-0 overflow-hidden", className)}
     >
       <div className="p-4 flex items-center justify-between">

--- a/src/features/codingChallenges/components/ExerciseCard.tsx
+++ b/src/features/codingChallenges/components/ExerciseCard.tsx
@@ -20,7 +20,8 @@ export function ExerciseCard({ exercise, categoryColors }: ExerciseCardProps) {
   const previewDescription = exercise.description.split('\n')[0];
 
   return (
-    <Link 
+    <Link
+      data-component="ExerciseCard"
       href={`/exercises/${exercise.slug}`}
       className="block transition-colors hover:bg-muted/50"
     >

--- a/src/features/codingChallenges/components/ExerciseClient.tsx
+++ b/src/features/codingChallenges/components/ExerciseClient.tsx
@@ -133,7 +133,8 @@ export function ExerciseClient({ exercise }: Props) {
   }, []);
 
   return (
-    <motion.div 
+    <motion.div
+      data-component="ExerciseClient"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
@@ -480,11 +481,14 @@ function TestCaseAccordion({ test, index, result }: TestCaseAccordionProps) {
   const hasRun = result !== undefined;
 
   return (
-    <div className={cn(
-      "rounded-lg border",
-      hasRun && (isPassed ? "bg-green-500/10 border-green-500/20" : "bg-destructive/10 border-destructive/20"),
-      !hasRun && "bg-card"
-    )}>
+    <div
+      data-component="TestCaseAccordion"
+      className={cn(
+        "rounded-lg border",
+        hasRun && (isPassed ? "bg-green-500/10 border-green-500/20" : "bg-destructive/10 border-destructive/20"),
+        !hasRun && "bg-card"
+      )}
+    >
       <button
         className="flex w-full items-center justify-between p-4"
         onClick={() => setIsOpen(!isOpen)}

--- a/src/features/codingChallenges/components/ExercisePageSkeleton.tsx
+++ b/src/features/codingChallenges/components/ExercisePageSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export function ExercisePageSkeleton() {
   return (
-    <div className="min-h-screen bg-background">
+    <div data-component="ExercisePageSkeleton" className="min-h-screen bg-background">
       {/* Header Skeleton */}
       <div className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="container flex h-14 max-w-screen-2xl items-center justify-between">


### PR DESCRIPTION
## Summary
- remove temporary `debugProps` helper
- keep `data-component` attributes directly on elements

## Testing
- `npm run lint`
- `npm run type-check`
