### PR TITLE
Refactor localStorage usage

### DIFF
--- a/src/features/codingChallenges/components/CodeEditor.tsx
+++ b/src/features/codingChallenges/components/CodeEditor.tsx
@@ -125,17 +125,17 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   const handleEditorDidMount: OnMount = useCallback((editor, monaco) => {
     editorRef.current = editor;
 
-    // Load saved code if it exists
-    if (typeof window !== "undefined") {
-      try {
-        const savedCode = localStorage.getItem(`${slug}-code`);
-        if (savedCode) {
-          editor.setValue(savedCode);
-        }
-      } catch (err) {
-        console.error("Failed to load saved code:", err);
-      }
+// Load saved code if it exists
+if (typeof window !== "undefined") {
+  try {
+   const savedCode = getLocalStorageValue(`${slug}-code`, null);
+    if (savedCode) {
+      editor.setValue(savedCode);
     }
+  } catch (err) {
+    console.error("Failed to load saved code:", err);
+  }
+}
 
     // Add custom keybinding for Cmd/Ctrl + Enter
     editor.addCommand(

--- a/src/features/codingChallenges/components/CodeEditor.tsx
+++ b/src/features/codingChallenges/components/CodeEditor.tsx
@@ -8,6 +8,7 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
+import { getLocalStorageValue, setLocalStorageValue } from "@/lib/storage";
 import {
   Select,
   SelectContent,
@@ -35,15 +36,6 @@ export type CodeEditorHandle = {
   runTests: () => Promise<void>;
 };
 
-const getStorageValue = <T,>(key: string, defaultValue: T): T => {
-  if (typeof window === "undefined") return defaultValue;
-  try {
-    const saved = localStorage.getItem(key);
-    return (saved as unknown as T) ?? defaultValue;
-  } catch {
-    return defaultValue;
-  }
-};
 
 export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function CodeEditor({
   defaultLanguage = "typescript",
@@ -61,10 +53,13 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
 
   // Initialize state from localStorage after mount
   useEffect(() => {
-    const savedLanguage = getStorageValue(`${slug}-language`, defaultLanguage) as "typescript" | "javascript";
+    const savedLanguage = getLocalStorageValue(
+      `${slug}-language`,
+      defaultLanguage
+    ) as "typescript" | "javascript";
     setLanguage(savedLanguage);
-    
-    const savedCode = getStorageValue(`${slug}-code`, null);
+
+    const savedCode = getLocalStorageValue(`${slug}-code`, null);
     if (savedCode && editorRef.current) {
       editorRef.current.setValue(savedCode);
     }
@@ -78,23 +73,18 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     }
 
     if (typeof window === "undefined") return;
-    try {
-      localStorage.setItem(`${slug}-language`, language);
-      onLanguageChange?.(language);
-    } catch (err) {
-      console.error("Failed to save language preference:", err);
-    }
+    setLocalStorageValue(`${slug}-language`, language);
+    onLanguageChange?.(language);
   }, [language, onLanguageChange, slug]);
 
   // Auto-save code changes
-  const handleEditorChange = useCallback((value: string | undefined) => {
-    if (typeof window === "undefined" || !value) return;
-    try {
-      localStorage.setItem(`${slug}-code`, value);
-    } catch (err) {
-      console.error("Failed to save code:", err);
-    }
-  }, [slug]);
+  const handleEditorChange = useCallback(
+    (value: string | undefined) => {
+      if (typeof window === "undefined" || !value) return;
+      setLocalStorageValue(`${slug}-code`, value);
+    },
+    [slug]
+  );
 
   const handleRunTests = useCallback(async () => {
     if (!editorRef.current) return;

--- a/src/features/codingChallenges/components/ExerciseClient.tsx
+++ b/src/features/codingChallenges/components/ExerciseClient.tsx
@@ -32,6 +32,7 @@ import {
 } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
+import { getLocalStorageValue } from "@/lib/storage";
 import Link from "next/link";
 import {
   Tooltip,
@@ -65,15 +66,6 @@ const KEYBOARD_SHORTCUTS = [
   { key: "Esc", description: "Exit Fullscreen" },
 ];
 
-const getStorageValue = <T,>(key: string, defaultValue: T): T => {
-  if (typeof window === "undefined") return defaultValue;
-  try {
-    const saved = localStorage.getItem(key);
-    return (saved as unknown as T) ?? defaultValue;
-  } catch {
-    return defaultValue;
-  }
-};
 
 export function ExerciseClient({ exercise }: Props) {
   const [testResults, setTestResults] = useState<TestResult[]>([]);
@@ -87,7 +79,10 @@ export function ExerciseClient({ exercise }: Props) {
 
   // Load saved language preference after mount
   useEffect(() => {
-    const savedLanguage = getStorageValue(`${exercise.slug}-language`, "javascript") as "typescript" | "javascript";
+    const savedLanguage = getLocalStorageValue(
+      `${exercise.slug}-language`,
+      "javascript"
+    ) as "typescript" | "javascript";
     setLanguage(savedLanguage);
   }, [exercise.slug]);
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,28 @@
+// Utilities for working with localStorage in a safe way
+
+/**
+ * Retrieve a value from localStorage and parse it to the correct type.
+ * Falls back to the provided default if reading fails.
+ */
+export const getLocalStorageValue = <T>(key: string, defaultValue: T): T => {
+  if (typeof window === "undefined") return defaultValue;
+  try {
+    const saved = window.localStorage.getItem(key);
+    return (saved as unknown as T) ?? defaultValue;
+  } catch {
+    return defaultValue;
+  }
+};
+
+/**
+ * Save a value to localStorage. Errors are swallowed to avoid runtime issues
+ * in unsupported environments or private browsing modes.
+ */
+export const setLocalStorageValue = <T>(key: string, value: T): void => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, String(value));
+  } catch {
+    // ignore write errors
+  }
+};

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -8,7 +8,13 @@ export const getLocalStorageValue = <T>(key: string, defaultValue: T): T => {
   if (typeof window === "undefined") return defaultValue;
   try {
     const saved = window.localStorage.getItem(key);
-    return (saved as unknown as T) ?? defaultValue;
+   if (saved === null) return defaultValue;
+   try {
+     return JSON.parse(saved) as T;
+   } catch {
+     // If parsing fails, return the raw string or default
+     return (saved as unknown as T) ?? defaultValue;
+   }
   } catch {
     return defaultValue;
   }
@@ -21,7 +27,8 @@ export const getLocalStorageValue = <T>(key: string, defaultValue: T): T => {
 export const setLocalStorageValue = <T>(key: string, value: T): void => {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(key, String(value));
+   const valueToStore = typeof value === 'object' ? JSON.stringify(value) : String(value);
+   window.localStorage.setItem(key, valueToStore);
   } catch {
     // ignore write errors
   }


### PR DESCRIPTION
## Summary
- centralize localStorage helpers in `src/lib/storage.ts`
- reuse helpers in `CodeEditor` and `ExerciseClient`

## Testing
- `npm run lint`
- `npm run type-check`
