### PR TITLE
Improve coding challenge types

### DIFF
--- a/src/app/exercises/page.tsx
+++ b/src/app/exercises/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { EXERCISES, CATEGORY_METHODS } from "@/features/codingChallenges/data/exercisesData";
+import { EXERCISES } from "@/features/codingChallenges/data/exercisesData";
+import { CATEGORY_METHODS } from "@/features/codingChallenges/types";
 import { ExerciseCard } from "@/features/codingChallenges/components/ExerciseCard";
 import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";

--- a/src/features/codingChallenges/components/CodeEditor.tsx
+++ b/src/features/codingChallenges/components/CodeEditor.tsx
@@ -8,6 +8,7 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
+import type { Language, TestResult } from "../types";
 import { getLocalStorageValue, setLocalStorageValue } from "@/lib/storage";
 import {
   Select,
@@ -17,19 +18,14 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-export type TestResult = {
-  passed: boolean;
-  message: string;
-  error?: string;
-};
 
 export type CodeEditorProps = {
-  defaultLanguage?: "typescript" | "javascript";
+  defaultLanguage?: Language;
   defaultValue?: string;
   className?: string;
   slug: string;
   onTestResults?: (results: TestResult[]) => void;
-  onLanguageChange?: (language: "typescript" | "javascript") => void;
+  onLanguageChange?: (language: Language) => void;
 };
 
 export type CodeEditorHandle = {
@@ -38,7 +34,7 @@ export type CodeEditorHandle = {
 
 
 export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function CodeEditor({
-  defaultLanguage = "typescript",
+  defaultLanguage = "typescript" as Language,
   defaultValue = "const solve = () => {\n  // Write your solution here\n}",
   className,
   slug,
@@ -48,7 +44,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [language, setLanguage] = useState<"typescript" | "javascript">(defaultLanguage);
+  const [language, setLanguage] = useState<Language>(defaultLanguage);
   const isInitialMount = useRef(true);
 
   // Initialize state from localStorage after mount
@@ -56,7 +52,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     const savedLanguage = getLocalStorageValue(
       `${slug}-language`,
       defaultLanguage
-    ) as "typescript" | "javascript";
+    ) as Language;
     setLanguage(savedLanguage);
 
     const savedCode = getLocalStorageValue(`${slug}-code`, null);
@@ -181,7 +177,7 @@ if (typeof window !== "undefined") {
         <div className="flex items-center justify-between w-full">
           <Select
             value={language}
-            onValueChange={(val) => setLanguage(val as "typescript" | "javascript")}
+            onValueChange={(val) => setLanguage(val as Language)}
           >
             <SelectTrigger className="w-[150px]">
               <SelectValue placeholder="Select language" />

--- a/src/features/codingChallenges/components/ExerciseCard.tsx
+++ b/src/features/codingChallenges/components/ExerciseCard.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import type { Exercise } from "../data/exercisesData";
+import type { Exercise } from "../types";
 
 type CategoryColors = {
   bg: string;

--- a/src/features/codingChallenges/components/ExerciseClient.tsx
+++ b/src/features/codingChallenges/components/ExerciseClient.tsx
@@ -10,7 +10,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { CodeEditor, type TestResult, type CodeEditorHandle } from "@/features/codingChallenges/components/CodeEditor";
+import { CodeEditor, type CodeEditorHandle } from "@/features/codingChallenges/components/CodeEditor";
+import type { Language, TestResult } from "../types";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { 
@@ -49,10 +50,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Markdown } from "@/components/ui/markdown";
-import type {
-  Exercise,
-  TestCase,
-} from "@/features/codingChallenges/data/exercisesData";
+import type { Exercise, TestCase } from "../types";
 
 type Props = {
   exercise: Exercise;
@@ -69,7 +67,7 @@ const KEYBOARD_SHORTCUTS = [
 
 export function ExerciseClient({ exercise }: Props) {
   const [testResults, setTestResults] = useState<TestResult[]>([]);
-  const [language, setLanguage] = useState<"typescript" | "javascript">("javascript");
+  const [language, setLanguage] = useState<Language>("javascript");
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [activeTab, setActiveTab] = useState("instructions");
   const editorRef = useRef<CodeEditorHandle>(null);
@@ -82,7 +80,7 @@ export function ExerciseClient({ exercise }: Props) {
     const savedLanguage = getLocalStorageValue(
       `${exercise.slug}-language`,
       "javascript"
-    ) as "typescript" | "javascript";
+    ) as Language;
     setLanguage(savedLanguage);
   }, [exercise.slug]);
 

--- a/src/features/codingChallenges/data/exercisesData.ts
+++ b/src/features/codingChallenges/data/exercisesData.ts
@@ -1,63 +1,5 @@
-/**
- * ------------------------------------------------------------------------
- *  1) CATEGORY_METHODS: One place to define valid categories and methods
- * ------------------------------------------------------------------------
- */
-export const CATEGORY_METHODS = {
-    array: ["reduce", "map", "filter", "forEach"] as const,
-    map: ["set", "get", "has"] as const,
-    object: ["keys", "values", "entries"] as const,
-    set: ["add", "has", "delete"] as const
-  } as const;
-  
-  /**
-   * ------------------------------------------------------------------------
-   *  2) Derived Types from CATEGORY_METHODS
-   * ------------------------------------------------------------------------
-   */
-  export type CategoryName = keyof typeof CATEGORY_METHODS;
-  
-  export type MethodName<T extends CategoryName> = typeof CATEGORY_METHODS[T][number];
-  
-  export type Category<T extends CategoryName = CategoryName> = {
-    name: T;
-    method: MethodName<T>;
-  };
-  
-  /**
-   * ------------------------------------------------------------------------
-   *  3) Educational Content Type (as defined)
-   * ------------------------------------------------------------------------
-   */
-  export type Education = {
-    concept: string;
-    explanation: string;
-    useCases: string[];
-    visualExample?: string;
-    commonMistakes?: string[];
-    tips?: string[];
-  };
-  
-  /**
-   * ------------------------------------------------------------------------
-   *  4) Basic Learning Exercise Types
-   * ------------------------------------------------------------------------
-   */
-  export type TestCase = {
-    input: unknown[];
-    expected: unknown;
-    message: string;
-  };
-  
-  export type Exercise<T extends CategoryName = CategoryName> = {
-    slug: string;
-    title: string;
-    description: string;
-    category: Category<T>;
-    education: Education;
-    starterCode: string;
-    testCases: TestCase[];
-  };
+import { z } from "zod";
+import { ExerciseSchema, type Exercise } from "../types";
   
   /**
    * ------------------------------------------------------------------------
@@ -66,7 +8,7 @@ export const CATEGORY_METHODS = {
    *     Education -> thorough, beginner-friendly explanation of `reduce`.
    * ------------------------------------------------------------------------
    */
-  export const EXERCISES: Exercise[] = [
+export const EXERCISES: Exercise[] = z.array(ExerciseSchema).parse([
     {
       slug: "reduce-sum",
       title: "Sum Numbers with reduce()",
@@ -427,5 +369,4 @@ Result: { a: 2, b: 1 }
         }
       ]
     }
-  ];
-  
+]);

--- a/src/features/codingChallenges/types.ts
+++ b/src/features/codingChallenges/types.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+export const LANGUAGES = ["typescript", "javascript"] as const;
+export const LanguageSchema = z.enum(LANGUAGES);
+export type Language = z.infer<typeof LanguageSchema>;
+
+export const CATEGORY_METHODS = {
+  array: ["reduce", "map", "filter", "forEach"] as const,
+  map: ["set", "get", "has"] as const,
+  object: ["keys", "values", "entries"] as const,
+  set: ["add", "has", "delete"] as const,
+} as const;
+
+const categoryNames = ["array", "map", "object", "set"] as const;
+export const CategoryNameSchema = z.enum(categoryNames);
+export type CategoryName = z.infer<typeof CategoryNameSchema>;
+
+const methodNames = [
+  ...CATEGORY_METHODS.array,
+  ...CATEGORY_METHODS.map,
+  ...CATEGORY_METHODS.object,
+  ...CATEGORY_METHODS.set,
+] as const;
+export const MethodNameSchema = z.enum(methodNames);
+export type MethodName = z.infer<typeof MethodNameSchema>;
+
+export const CategorySchema = z
+  .object({
+    name: CategoryNameSchema,
+    method: MethodNameSchema,
+  })
+  .superRefine((val, ctx) => {
+    if (!CATEGORY_METHODS[val.name].includes(val.method as never)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Method ${val.method} is not valid for ${val.name}`,
+      });
+    }
+  });
+export type Category = z.infer<typeof CategorySchema>;
+
+export const EducationSchema = z.object({
+  concept: z.string(),
+  explanation: z.string(),
+  useCases: z.array(z.string()),
+  visualExample: z.string().optional(),
+  commonMistakes: z.array(z.string()).optional(),
+  tips: z.array(z.string()).optional(),
+});
+export type Education = z.infer<typeof EducationSchema>;
+
+export const TestCaseSchema = z.object({
+  input: z.array(z.unknown()),
+  expected: z.unknown(),
+  message: z.string(),
+});
+export type TestCase = z.infer<typeof TestCaseSchema>;
+
+export const ExerciseSchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  description: z.string(),
+  category: CategorySchema,
+  education: EducationSchema,
+  starterCode: z.string(),
+  testCases: z.array(TestCaseSchema),
+});
+export type Exercise = z.infer<typeof ExerciseSchema>;
+
+export const TestResultSchema = z.object({
+  passed: z.boolean(),
+  message: z.string(),
+  error: z.string().optional(),
+});
+export type TestResult = z.infer<typeof TestResultSchema>;


### PR DESCRIPTION
## Summary
- centralize exercise-related types with Zod schemas
- validate exercise API inputs and outputs with Zod
- update components to use shared types
- centralize language type

## Testing
- `npm run lint`
- `npm run type-check`
