### PR TITLE
Add Jest setup and sample tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({ dir: './' })
+
+const customConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+}
+
+module.exports = createJestConfig(customConfig)

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "jest"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0-rc.0",

--- a/src/app/api/exercises/__tests__/route.test.ts
+++ b/src/app/api/exercises/__tests__/route.test.ts
@@ -1,0 +1,14 @@
+/** @jest-environment node */
+/* eslint-disable boundaries/element-types */
+import { GET } from "../route"
+import { EXERCISES } from "@/features/codingChallenges/data/exercisesData"
+
+describe("GET /api/exercises", () => {
+  it("returns all exercises", async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Cache-Control")).toContain("s-maxage")
+    const data = await res.json()
+    expect(data).toEqual({ exercises: EXERCISES })
+  })
+})

--- a/src/features/codingChallenges/components/__tests__/ExerciseCard.test.tsx
+++ b/src/features/codingChallenges/components/__tests__/ExerciseCard.test.tsx
@@ -1,0 +1,14 @@
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { ExerciseCard } from "../ExerciseCard"
+import { EXERCISES } from "@/features/codingChallenges/data/exercisesData"
+
+describe("ExerciseCard", () => {
+  it("links to the exercise page and shows title", () => {
+    const exercise = EXERCISES[0]!;
+    render(<ExerciseCard exercise={exercise} />)
+    expect(screen.getByText(exercise.title)).toBeInTheDocument()
+    const link = screen.getByRole("link")
+    expect(link).toHaveAttribute("href", `/exercises/${exercise.slug}`)
+  })
+})

--- a/src/hooks/useDebounce.test.ts
+++ b/src/hooks/useDebounce.test.ts
@@ -1,0 +1,26 @@
+import { renderHook, act } from "@testing-library/react"
+import { useDebounce } from "./useDebounce"
+
+describe("useDebounce", () => {
+  jest.useFakeTimers()
+
+  it("updates value after delay", () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 200), {
+      initialProps: { value: "a" },
+    })
+
+    expect(result.current).toBe("a")
+
+    rerender({ value: "b" })
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+    // still old value
+    expect(result.current).toBe("a")
+
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+    expect(result.current).toBe("b")
+  })
+})

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,0 +1,28 @@
+import { getLocalStorageValue, setLocalStorageValue } from "./storage"
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe("getLocalStorageValue", () => {
+  it("returns default when window is undefined", () => {
+    const originalWindow = global.window
+    // @ts-expect-error temporary remove window
+    delete global.window
+    const result = getLocalStorageValue("missing", 42)
+    global.window = originalWindow
+    expect(result).toBe(42)
+  })
+
+  it("retrieves stored value", () => {
+    localStorage.setItem("foo", JSON.stringify(5))
+    expect(getLocalStorageValue("foo", 0)).toBe(5)
+  })
+})
+
+describe("setLocalStorageValue", () => {
+  it("saves value to localStorage", () => {
+    setLocalStorageValue("bar", { a: 1 })
+    expect(JSON.parse(localStorage.getItem("bar") ?? "{}")).toEqual({ a: 1 })
+  })
+})

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,11 @@
+import { cn } from "./utils"
+
+describe("cn", () => {
+  it("merges class names", () => {
+    expect(cn("foo", false && "bar", "baz")).toBe("foo baz")
+  })
+
+  it("dedupes tailwind classes", () => {
+    expect(cn("p-2", "p-4")).toBe("p-4")
+  })
+})


### PR DESCRIPTION
## Summary
- add Jest config using `next/jest`
- configure global setup for RTL
- enable `npm test` script
- add tests for utilities, hooks, components and API routes

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test --silent`