### PR TITLE
Add CI workflow and dev scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run ci
+      - run: npm run build

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "true" ] && echo "husky (debug) - $*"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  if [ "$HUSKY" = "skip" ]; then
+    debug "HUSKY is set to skip, skipping hook"
+    exit 0
+  fi
+  if [ -n "$CI" ]; then
+    debug "CI detected, skipping hook"
+    exit 0
+  fi
+fi
+
+export PATH="./node_modules/.bin:$PATH"
+
+if [ -f ~/.huskyrc ]; then
+  . ~/.huskyrc
+fi
+
+exec "$@"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run ci

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+build
+coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "arrowParens": "avoid"
+}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "lint:fix": "next lint --fix",
     "type-check": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "format": "prettier --cache --write .",
+    "ci": "npm run lint && npm run type-check && npm run test",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0-rc.0",
@@ -56,7 +60,18 @@
     "postcss": "^8",
     "shadcn-ui": "^0.9.4",
     "tailwindcss": "^3.4.1",
+    "prettier": "^3.2.5",
+    "husky": "^9.0.11",
+    "lint-staged": "^15.2.0",
     "undefined": "^0.1.0"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "next lint --fix"
+    ],
+    "*.{js,jsx,ts,tsx,json,css,md}": [
+      "prettier --write"
+    ]
   },
   "_typescript_note": "TypeScript is a runtime dependency because we use it to transpile user-submitted TypeScript code"
 }


### PR DESCRIPTION
## Summary
- add npm scripts for format, lint fixes and CI tasks
- configure Prettier and lint-staged
- set up Husky hooks
- add GitHub Actions workflow

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
