### PR TITLE
Redesign homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,29 +1,38 @@
 import type { ReactElement } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import {
+  HeroSection,
+  StatsPebble,
+  FinalBanner,
+  MicroNav,
+} from "@/features/home/components";
+import { Code2, Layers, Trophy } from "lucide-react";
 
 export default function Home(): ReactElement {
   return (
-    <section
-      data-component="HomePage"
-      className="container mx-auto flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center"
-    >
-      <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
-        JavaScript Methods Learning
-      </h1>
-      <p className="text-lg text-muted-foreground">
-        Practice essential JavaScript methods through short, interactive
-        exercises.
-      </p>
-      <div className="flex flex-col items-center gap-4 sm:flex-row">
-        <Button asChild>
-          <Link href="/exercises">Browse Exercises</Link>
-        </Button>
-        <Button variant="secondary" asChild>
-          <Link href="/exercises">Start Now</Link>
-        </Button>
-      </div>
-    </section>
+    <main data-component="HomePage" className="flex flex-col">
+      <MicroNav />
+      <HeroSection />
+      <section className="bg-muted py-12">
+        <div className="container mx-auto flex justify-center gap-6">
+          <StatsPebble
+            icon={<Code2 className="h-6 w-6" />}
+            value={50}
+            label="Exercises"
+          />
+          <StatsPebble
+            icon={<Layers className="h-6 w-6" />}
+            value={4}
+            label="Categories"
+          />
+          <StatsPebble
+            icon={<Trophy className="h-6 w-6" />}
+            value={12}
+            label="Techniques"
+          />
+        </div>
+      </section>
+      <FinalBanner />
+    </main>
   );
 }
 Home.displayName = "Home";

--- a/src/features/home/components/FinalBanner.tsx
+++ b/src/features/home/components/FinalBanner.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export function FinalBanner() {
+  return (
+    <section
+      data-component="FinalBanner"
+      className="flex min-h-[480px] flex-col items-center justify-center bg-gradient-to-br from-teal-500 to-indigo-600 text-background"
+    >
+      <h2 className="mb-6 text-3xl font-semibold md:text-5xl">
+        Ready to build muscle memory?
+      </h2>
+      <Button size="lg" className="text-lg" asChild>
+        <Link href="/exercises">Start the Challenges</Link>
+      </Button>
+    </section>
+  );
+}
+FinalBanner.displayName = "FinalBanner";

--- a/src/features/home/components/HeroSection.tsx
+++ b/src/features/home/components/HeroSection.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const codeSnippet = `const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0);`;
+
+export function HeroSection() {
+  return (
+    <section
+      data-component="HeroSection"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-br from-indigo-900 via-slate-900 to-cyan-900 text-white"
+    >
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(99,102,241,0.4),transparent)]" />
+      <div className="relative z-10 grid max-w-6xl grid-cols-1 items-center gap-12 px-4 md:grid-cols-2">
+        <div className="space-y-6 text-center md:text-left">
+          <motion.h1
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            className="text-4xl font-bold md:text-6xl"
+          >
+            Master JavaScript Methods
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7 }}
+            className="text-lg text-muted-foreground"
+          >
+            Short, interactive challenges to sharpen your skills.
+          </motion.p>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            className="flex justify-center gap-4 md:justify-start"
+          >
+            <Button size="lg" asChild>
+              <Link href="/exercises">Start the Challenges</Link>
+            </Button>
+            <Button variant="secondary" size="lg" asChild>
+              <Link href="/exercises">Browse Exercises</Link>
+            </Button>
+          </motion.div>
+        </div>
+        <motion.pre
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.9 }}
+          className={cn(
+            "rounded-xl border border-white/20 bg-black/50 p-6 font-mono text-sm backdrop-blur-xl",
+          )}
+        >
+          <code>{codeSnippet}</code>
+        </motion.pre>
+      </div>
+    </section>
+  );
+}
+HeroSection.displayName = "HeroSection";

--- a/src/features/home/components/MicroNav.tsx
+++ b/src/features/home/components/MicroNav.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function MicroNav() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY >= 64);
+    onScroll();
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <nav
+      data-component="MicroNav"
+      className={cn(
+        "fixed left-0 right-0 top-0 z-30 transition-transform duration-300",
+        visible ? "translate-y-0" : "-translate-y-full",
+      )}
+    >
+      <div className="mx-auto flex h-12 max-w-5xl items-center justify-between rounded-b border-b border-border/50 bg-background/80 px-4 backdrop-blur">
+        <Link href="/" className="font-bold">
+          JSWB
+        </Link>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" asChild>
+            <Link href="/exercises">Log in</Link>
+          </Button>
+          <Button size="icon" variant="ghost" asChild>
+            <Link href="/exercises">
+              <span className="sr-only">Menu</span>≡
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </nav>
+  );
+}
+MicroNav.displayName = "MicroNav";

--- a/src/features/home/components/StatsPebble.tsx
+++ b/src/features/home/components/StatsPebble.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+export type StatsPebbleProps = {
+  icon: ReactNode;
+  label: string;
+  value: number | string;
+  className?: string;
+};
+
+export function StatsPebble({
+  icon,
+  label,
+  value,
+  className,
+}: StatsPebbleProps) {
+  return (
+    <motion.div
+      data-component="StatsPebble"
+      whileHover={{ y: -4 }}
+      className={cn(
+        "flex h-32 w-32 flex-col items-center justify-center rounded-2xl bg-muted text-foreground shadow-inner",
+        className,
+      )}
+    >
+      <div className="mb-2 text-primary">{icon}</div>
+      <div className="text-lg font-bold">{value}</div>
+      <div className="text-xs text-muted-foreground">{label}</div>
+    </motion.div>
+  );
+}
+StatsPebble.displayName = "StatsPebble";

--- a/src/features/home/components/index.ts
+++ b/src/features/home/components/index.ts
@@ -1,0 +1,4 @@
+export * from "./HeroSection";
+export * from "./StatsPebble";
+export * from "./FinalBanner";
+export * from "./MicroNav";


### PR DESCRIPTION
## Summary
- overhaul the home page layout
- add Hero section with gradient, code snippet and CTAs
- show stats in neumorphic style
- provide final banner call-to-action
- include sticky micro navigation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
