### PR TITLE
Improve homepage styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,7 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
+    --brand: 217 88% 56%;
     --foreground: 0 0% 3.9%;
     --card: 0 0% 100%;
     --card-foreground: 0 0% 3.9%;
@@ -44,6 +45,7 @@
   }
   .dark {
     --background: 0 0% 3.9%;
+    --brand: 217 88% 56%;
     --foreground: 0 0% 98%;
     --card: 0 0% 3.9%;
     --card-foreground: 0 0% 98%;
@@ -53,8 +55,8 @@
     --primary-foreground: 0 0% 9%;
     --secondary: 0 0% 14.9%;
     --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
+    --muted: 0 0% 18%;
+    --muted-foreground: 0 0% 75%;
     --accent: 0 0% 14.9%;
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,16 +8,22 @@ import {
   HowItWorksSection,
   PopularChallengesSection,
 } from "@/features/home/components";
+import { Separator } from "@/components/ui/separator";
 
 export default function Home(): ReactElement {
   return (
     <main data-component="HomePage" className="flex flex-col">
       <MicroNav />
       <HeroSection />
+      <Separator className="my-12" />
       <StatsSection />
+      <Separator className="my-12" />
       <FeaturesSection />
+      <Separator className="my-12" />
       <HowItWorksSection />
+      <Separator className="my-12" />
       <PopularChallengesSection />
+      <Separator className="my-12" />
       <FinalBanner />
     </main>
   );

--- a/src/features/home/components/FeaturesSection.tsx
+++ b/src/features/home/components/FeaturesSection.tsx
@@ -6,17 +6,17 @@ import { Rocket, BookOpen, Lightbulb } from "lucide-react";
 
 const FEATURES = [
   {
-    icon: <Rocket className="h-6 w-6" />,
+    icon: <Rocket className="h-6 w-6" strokeWidth={1.5} />,
     title: "Hands-on Practice",
     description: "Write and run code right in your browser.",
   },
   {
-    icon: <BookOpen className="h-6 w-6" />,
+    icon: <BookOpen className="h-6 w-6" strokeWidth={1.5} />,
     title: "Real Examples",
     description: "Learn through practical, everyday tasks.",
   },
   {
-    icon: <Lightbulb className="h-6 w-6" />,
+    icon: <Lightbulb className="h-6 w-6" strokeWidth={1.5} />,
     title: "Track Progress",
     description: "See which challenges you've completed.",
   },
@@ -29,6 +29,10 @@ function FeatureItem({ icon, title, description }: Feature): ReactElement {
     <motion.div
       data-component="FeatureItem"
       whileHover={{ y: -4 }}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.4 }}
       className="text-center"
     >
       <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary shadow">

--- a/src/features/home/components/HeroSection.tsx
+++ b/src/features/home/components/HeroSection.tsx
@@ -1,29 +1,29 @@
 "use client";
 
 import Link from "next/link";
-import { motion } from "framer-motion";
+import { motion, useScroll, useTransform } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 const codeSnippet = `const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0);`;
 
-const PARTICLES = 50;
+const GRID_COLS = 10;
+const GRID_ROWS = 5;
 
 function ParticleBackground() {
+  const { scrollY } = useScroll();
+  const y = useTransform(scrollY, [0, 300], [0, -80]);
+
   return (
-    <div className="absolute inset-0 opacity-[0.03]">
-      {Array.from({ length: PARTICLES }).map((_, i) => (
-        <div
-          key={i}
-          className="absolute h-1 w-1 rounded-full bg-white"
-          style={{
-            top: `${Math.random() * 100}%`,
-            left: `${Math.random() * 100}%`,
-            opacity: Math.random() * 0.5 + 0.1,
-          }}
-        />
-      ))}
-    </div>
+    <motion.div className="absolute inset-0 opacity-[0.03]" style={{ y }}>
+      <div className="grid h-full w-full grid-cols-10 grid-rows-5">
+        {Array.from({ length: GRID_COLS * GRID_ROWS }).map((_, i) => (
+          <div key={i} className="flex items-center justify-center">
+            <div className="h-1 w-1 rounded-full bg-white" />
+          </div>
+        ))}
+      </div>
+    </motion.div>
   );
 }
 
@@ -31,17 +31,17 @@ export function HeroSection() {
   return (
     <section
       data-component="HeroSection"
-      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-radial from-indigo-900 via-blue-900 to-cyan-800 text-white"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-b from-brand via-brand/80 to-brand/60 text-white"
     >
       <ParticleBackground />
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(99,102,241,0.4),transparent)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,hsla(var(--brand),0.3),transparent)]" />
       <div className="relative z-10 grid max-w-6xl grid-cols-1 items-center gap-12 px-4 md:grid-cols-2">
         <div className="space-y-6 text-center md:text-left">
           <motion.h1
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
-            className="text-5xl font-bold md:text-7xl"
+            className="text-5xl font-bold md:text-6xl lg:text-7xl"
           >
             Master{" "}
             <span className="bg-gradient-to-r from-cyan-400 to-teal-400 bg-clip-text text-transparent">
@@ -53,7 +53,7 @@ export function HeroSection() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.7 }}
-            className="text-xl text-muted-foreground"
+            className="text-lg md:text-xl text-muted-foreground"
           >
             Short, interactive challenges to sharpen your skills.
           </motion.p>
@@ -61,12 +61,21 @@ export function HeroSection() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
-            className="flex justify-center gap-4 md:justify-start"
+            className="flex flex-col justify-center gap-4 sm:flex-row md:justify-start"
           >
-            <Button size="lg" asChild>
+            <Button
+              size="lg"
+              className="transition-transform duration-200 hover:scale-105 focus:scale-105"
+              asChild
+            >
               <Link href="/exercises">Start the Challenges</Link>
             </Button>
-            <Button variant="secondary" size="lg" asChild>
+            <Button
+              variant="secondary"
+              size="lg"
+              className="transition-transform duration-200 hover:scale-105 focus:scale-105"
+              asChild
+            >
               <Link href="/exercises">Browse Exercises</Link>
             </Button>
           </motion.div>

--- a/src/features/home/components/HowItWorksSection.tsx
+++ b/src/features/home/components/HowItWorksSection.tsx
@@ -6,19 +6,19 @@ import { MousePointer, Code2, Trophy } from "lucide-react";
 
 const STEPS = [
   {
-    icon: <MousePointer className="h-6 w-6 text-white" />,
+    icon: <MousePointer className="h-6 w-6 text-white" strokeWidth={1.5} />,
     title: "Choose a Challenge",
     description: "Pick from our library of exercises.",
     color: "violet",
   },
   {
-    icon: <Code2 className="h-6 w-6 text-white" />,
+    icon: <Code2 className="h-6 w-6 text-white" strokeWidth={1.5} />,
     title: "Write Your Solution",
     description: "Solve it directly in the editor.",
     color: "cyan",
   },
   {
-    icon: <Trophy className="h-6 w-6 text-white" />,
+    icon: <Trophy className="h-6 w-6 text-white" strokeWidth={1.5} />,
     title: "Test & Learn",
     description: "Run tests and learn from the results.",
     color: "lime",

--- a/src/features/home/components/StatsPebble.tsx
+++ b/src/features/home/components/StatsPebble.tsx
@@ -21,8 +21,12 @@ export function StatsPebble({
     <motion.div
       data-component="StatsPebble"
       whileHover={{ y: -4 }}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.4 }}
       className={cn(
-        "flex h-36 w-36 flex-col items-center justify-center rounded-xl bg-white/90 text-foreground shadow-md backdrop-blur-md",
+        "flex h-36 w-36 flex-col items-center justify-center rounded-xl bg-gradient-to-br from-white/80 to-white/60 text-foreground shadow-lg backdrop-blur-md dark:from-white/20 dark:to-white/10",
         className,
       )}
     >

--- a/src/features/home/components/StatsSection.tsx
+++ b/src/features/home/components/StatsSection.tsx
@@ -7,17 +7,17 @@ export function StatsSection(): ReactElement {
     <section data-component="StatsSection" className="bg-muted py-12">
       <div className="container mx-auto flex flex-wrap items-center justify-center gap-8">
         <StatsPebble
-          icon={<Code2 className="h-6 w-6" />}
+          icon={<Code2 className="h-6 w-6" strokeWidth={1.5} />}
           value={50}
           label="Exercises"
         />
         <StatsPebble
-          icon={<Layers className="h-6 w-6" />}
+          icon={<Layers className="h-6 w-6" strokeWidth={1.5} />}
           value={4}
           label="Categories"
         />
         <StatsPebble
-          icon={<Trophy className="h-6 w-6" />}
+          icon={<Trophy className="h-6 w-6" strokeWidth={1.5} />}
           value={12}
           label="Techniques"
         />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,7 @@ export default {
   theme: {
     extend: {
       colors: {
+        brand: "hsl(var(--brand))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         card: {


### PR DESCRIPTION
## Summary
- add brand color to Tailwind and theme
- tweak dark mode muted colors
- refine Hero section with parallax particles and button effects
- give StatsPebble gradient depth and entrance motion
- animate features and standardize icon weights
- add separators between sections

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
