### PR TITLE
Add homepage-specific dark mode toggle

### DIFF
--- a/src/features/homepage/components/home-page.tsx
+++ b/src/features/homepage/components/home-page.tsx
@@ -8,10 +8,13 @@ import { FinalCta } from "@/features/homepage/components/sections/final-cta";
 import { NavigationBar } from "@/features/homepage/components/ui/navigation-bar";
 import { FloatingCta } from "@/features/homepage/components/ui/floating-cta";
 import { LoadingScreen } from "@/features/homepage/components/ui/loading-screen";
+import { NoiseTexture } from "@/features/homepage/components/ui/noise-texture";
 import { useLoading } from "@/features/homepage/hooks/useLoading";
 import { useScrollProgress } from "@/features/homepage/hooks/useScrollProgress";
+import { useDarkMode } from "@/features/homepage/hooks/useDarkMode";
 
 export function HomePage() {
+  const { isDark, toggleDark } = useDarkMode();
   const { isLoading } = useLoading();
   const { showNav, scrollProgress } = useScrollProgress();
 
@@ -21,7 +24,14 @@ export function HomePage() {
 
   return (
     <div data-component="HomePage" className="relative">
-      {showNav && <NavigationBar scrollProgress={scrollProgress} />}
+      <NoiseTexture />
+      {showNav && (
+        <NavigationBar
+          scrollProgress={scrollProgress}
+          isDark={isDark}
+          toggleDark={toggleDark}
+        />
+      )}
       <Hero />
       <PopularChallenges />
       <HowItWorks />

--- a/src/features/homepage/components/sections/hero.tsx
+++ b/src/features/homepage/components/sections/hero.tsx
@@ -28,7 +28,7 @@ export function Hero() {
   return (
     <section ref={heroRef} className="relative min-h-screen overflow-hidden">
       <motion.div
-        className="absolute inset-0 bg-gradient-to-br from-background via-indigo-900/70 to-cyan-900/70"
+        className="absolute inset-0 bg-gradient-to-br from-background via-indigo-900/70 to-cyan-900/70 pointer-events-none z-0"
         style={{
           y: heroY,
           opacity: heroOpacity,

--- a/src/features/homepage/components/ui/dark-mode-toggle.tsx
+++ b/src/features/homepage/components/ui/dark-mode-toggle.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { memo } from "react";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type DarkModeToggleProps = {
+  isDark: boolean;
+  toggleDark: () => void;
+};
+
+/**
+ * Dark Mode Toggle component
+ *
+ * Button that switches between light and dark themes
+ */
+export const DarkModeToggle = memo(function DarkModeToggle({
+  isDark,
+  toggleDark,
+}: DarkModeToggleProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="text-white hover:bg-white/10"
+      aria-label="Toggle dark mode"
+      onClick={toggleDark}
+    >
+      {isDark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+    </Button>
+  );
+});
+DarkModeToggle.displayName = "DarkModeToggle";

--- a/src/features/homepage/components/ui/navigation-bar.tsx
+++ b/src/features/homepage/components/ui/navigation-bar.tsx
@@ -4,9 +4,12 @@ import { memo } from "react";
 import { motion } from "framer-motion";
 import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DarkModeToggle } from "@/features/homepage/components/ui/dark-mode-toggle";
 
 type NavigationBarProps = {
   scrollProgress: number;
+  isDark: boolean;
+  toggleDark: () => void;
 };
 
 /**
@@ -16,6 +19,8 @@ type NavigationBarProps = {
  */
 export const NavigationBar = memo(function NavigationBar({
   scrollProgress,
+  isDark,
+  toggleDark,
 }: NavigationBarProps) {
   return (
     <motion.div
@@ -31,6 +36,7 @@ export const NavigationBar = memo(function NavigationBar({
           Digital Prism
         </div>
         <div className="flex items-center gap-4">
+          <DarkModeToggle isDark={isDark} toggleDark={toggleDark} />
           <Button variant="ghost" className="text-white hover:bg-white/10">
             Log in
           </Button>

--- a/src/features/homepage/components/ui/particle-background.tsx
+++ b/src/features/homepage/components/ui/particle-background.tsx
@@ -17,7 +17,7 @@ export const ParticleBackground = memo(function ParticleBackground({
   opacity = 0.02,
 }: ParticleBackgroundProps) {
   return (
-    <div className="absolute inset-0" style={{ opacity }}>
+    <div className="absolute inset-0 pointer-events-none" style={{ opacity }}>
       {Array.from({ length: count }).map((_, i) => (
         <div
           key={i}

--- a/src/features/homepage/hooks/useDarkMode.ts
+++ b/src/features/homepage/hooks/useDarkMode.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Custom hook for toggling dark mode
+ *
+ * Applies or removes the `dark` class on the html element
+ */
+export function useDarkMode(defaultDark = true) {
+  const [isDark, setIsDark] = useState(defaultDark);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", isDark);
+  }, [isDark]);
+
+  const toggleDark = () => setIsDark((prev) => !prev);
+
+  return { isDark, toggleDark };
+}


### PR DESCRIPTION
## Summary
- remove global dark theme and noise texture from root layout
- add dark mode toggle with default dark mode
- apply noise texture only on homepage
- show theme toggle in homepage navigation bar

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
