### PR TITLE
Fix homepage visuals

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -109,13 +109,13 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-  @apply bg-black/20;
+  @apply bg-gray-200 dark:bg-gray-700;
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-cyan-500/20 rounded;
+  @apply bg-cyan-500/40 dark:bg-cyan-400/40 rounded;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  @apply bg-cyan-500/40;
+  @apply bg-cyan-500/60 dark:bg-cyan-400/60;
 }

--- a/src/features/homepage/components/sections/hero.tsx
+++ b/src/features/homepage/components/sections/hero.tsx
@@ -34,7 +34,7 @@ export function Hero() {
           opacity: heroOpacity,
         }}
       >
-        <ParticleBackground count={50} opacity={0.02} />
+        <ParticleBackground count={50} opacity={0.1} />
       </motion.div>
 
       <div className="container relative grid items-center h-screen max-w-7xl grid-cols-1 px-4 mx-auto lg:grid-cols-12 gap-y-12">

--- a/src/features/homepage/components/sections/how-it-works.tsx
+++ b/src/features/homepage/components/sections/how-it-works.tsx
@@ -14,14 +14,14 @@ export function HowItWorks() {
     <section className="py-24 bg-background relative">
       <div className="container max-w-7xl mx-auto px-4 relative z-10">
         <motion.h2
-          className="text-3xl font-bold text-center text-white mb-4"
+          className="text-3xl font-bold text-center text-foreground mb-4"
           {...fadeInUp(0)}
           viewport={{ once: true, margin: "-100px" }}
         >
           How It Works
         </motion.h2>
         <motion.div
-          className="max-w-xl mx-auto text-center mb-16 text-white/70"
+          className="max-w-xl mx-auto text-center mb-16 text-muted-foreground"
           {...fadeInUp(0.1)}
           viewport={{ once: true, margin: "-100px" }}
         >

--- a/src/features/homepage/components/sections/popular-challenges.tsx
+++ b/src/features/homepage/components/sections/popular-challenges.tsx
@@ -14,14 +14,14 @@ export function PopularChallenges() {
     <section className="py-24 bg-gradient-to-b from-background to-gray-900/90 relative">
       <div className="container max-w-7xl mx-auto px-4 relative z-10">
         <motion.h2
-          className="text-3xl font-bold text-center text-white mb-4"
+          className="text-3xl font-bold text-center text-foreground mb-4"
           {...fadeInUp(0)}
           viewport={{ once: true, margin: "-100px" }}
         >
           Popular Challenges
         </motion.h2>
         <motion.div
-          className="max-w-xl mx-auto text-center mb-16 text-white/70"
+          className="max-w-xl mx-auto text-center mb-16 text-muted-foreground"
           {...fadeInUp(0.1)}
           viewport={{ once: true, margin: "-100px" }}
         >

--- a/src/features/homepage/components/ui/code-card.tsx
+++ b/src/features/homepage/components/ui/code-card.tsx
@@ -47,8 +47,6 @@ console.log(result) // [2, 4, 6]`;
   // Typing animation
   useEffect(() => {
     if (!isTyping) return;
-    let testInterval: NodeJS.Timeout | undefined;
-    let startTestsTimeout: NodeJS.Timeout | undefined;
 
     const typingTimeout = setTimeout(() => {
       if (typedCode.length < codeSnippet.length) {


### PR DESCRIPTION
## Summary
- show the particle backdrop more clearly
- fix text contrast in light mode
- tweak scrollbar colors for both themes
- clean up unused vars in CodeCard

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
