### PR TITLE
Refactor run-tests API

### DIFF
--- a/src/app/api/exercises/[slug]/run-tests/route.ts
+++ b/src/app/api/exercises/[slug]/run-tests/route.ts
@@ -1,14 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { EXERCISES } from "@/features/codingChallenges/data/exercisesData";
-import {
-  LanguageSchema,
-  TestResultSchema,
-  type TestResult,
-} from "@/features/codingChallenges/types";
+import { LanguageSchema } from "@/features/codingChallenges/types";
+import { runIsolatedTests } from "@/features/codingChallenges/lib/runIsolatedTests";
+import { transpile } from "@/features/codingChallenges/lib/transpile";
 import { z } from "zod";
-import ivm from "isolated-vm";
-import ts from "typescript";
-import { logger } from "@/lib/logger";
 
 const RequestBodySchema = z.object({
   code: z.string(),
@@ -19,192 +14,38 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
 ): Promise<NextResponse> {
-  let isolate: ivm.Isolate | undefined;
+  const { slug } = await params;
+  const exercise = EXERCISES.find((ex) => ex.slug === slug);
 
-  try {
-    // 1) Identify the exercise
-    const { slug } = await params;
-    const exercise = EXERCISES.find((ex) => ex.slug === slug);
-    if (!exercise) {
-      return NextResponse.json(
-        { error: "Exercise not found" },
-        { status: 404 },
-      );
-    }
+  if (!exercise) {
+    return NextResponse.json({ error: "Exercise not found" }, { status: 404 });
+  }
 
-    // 2) Parse user code and language
-    const body = await request.json();
-    const parsed = RequestBodySchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: "Invalid request", issues: parsed.error.format() },
-        { status: 400 },
-      );
-    }
-    const { code, language } = parsed.data;
+  const body = await request.json();
+  const parsed = RequestBodySchema.safeParse(body);
 
-    // 3) If TypeScript, transpile to JavaScript
-    let finalCode = code;
-    if (language === "typescript") {
-      const result = ts.transpileModule(code, {
-        compilerOptions: {
-          module: ts.ModuleKind.ESNext,
-          target: ts.ScriptTarget.ESNext,
-          strict: true,
-        },
-        reportDiagnostics: true,
-      });
-
-      // Check for TypeScript compilation errors
-      if (result.diagnostics?.length) {
-        const messages = result.diagnostics.map((d) => {
-          const msg = ts.flattenDiagnosticMessageText(d.messageText, "\n");
-          const pos = d.file?.getLineAndCharacterOfPosition(d.start ?? 0);
-          const line = (pos?.line ?? 0) + 1;
-          const col = (pos?.character ?? 0) + 1;
-          return `TS Error at ${line}:${col} - ${msg}`;
-        });
-        return NextResponse.json(
-          { error: messages.join("\n") },
-          { status: 400 },
-        );
-      }
-
-      finalCode = result.outputText;
-    }
-
-    // 4) Create an isolate + context
-    const memoryMb = Number(process.env.ISOLATE_MEMORY_MB ?? 8);
-    isolate = new ivm.Isolate({ memoryLimit: memoryMb });
-    const context = isolate.createContextSync();
-    const jail = context.global;
-    jail.setSync("global", jail.derefInto());
-
-    // 5) Provide a snippet logger (sync callback) in the isolate
-    jail.setSync(
-      "myLog",
-      new ivm.Callback(
-        (...args: unknown[]) => logger.info("[Isolate log]", ...args),
-        { sync: true },
-      ),
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request", issues: parsed.error.format() },
+      { status: 400 },
     );
-
-    // 6) Build snippet which:
-    //    - loads user code (attaches solve => globalThis.solve)
-    //    - runs tests
-    //    - stores final { success, results } in globalThis.__myResult__
-    const codeWithGlobal = `${finalCode}\nif (typeof solve === 'function') globalThis.solve = solve;\n`;
-    const userCodeLiteral = JSON.stringify(codeWithGlobal);
-    // Escape backticks to avoid breaking the template literal
-    const testCasesLiteral = JSON.stringify(exercise.testCases).replace(
-      /`/g,
-      "\\`",
-    );
-
-    const snippet = `
-myLog("[snippet] Starting snippet...");
-
-try {
-  // Evaluate user code
-  const userCodeString = ${userCodeLiteral};
-  myLog("[snippet] userCodeString length:", userCodeString.length);
-  new Function("globalThis", userCodeString)(globalThis);
-
-  // Check for solve
-  if (typeof globalThis.solve !== "function") {
-    throw new Error("No solve() function found in user code.");
   }
 
-  // Parse test cases
-  const testCases = JSON.parse(\`${testCasesLiteral}\`);
-  const results = [];
+  const { code, language } = parsed.data;
+  const transpiled = transpile(code, language);
 
-  myLog("[snippet] testCases length:", testCases.length);
-
-  for (const [index, test] of testCases.entries()) {
-    myLog("[snippet] Running test #", index + 1, "with input:", test.input);
-    let output;
-    try {
-      output = globalThis.solve(...test.input);
-    } catch (err) {
-      results.push({ passed: false, message: test.message, error: String(err) });
-      continue;
-    }
-
-    if (output === undefined) {
-      results.push({
-        passed: false,
-        message: test.message,
-        error: "Function returned undefined. Make sure you're returning a value."
-      });
-      continue;
-    }
-
-    // Compare JSON for objects/arrays
-    const passed = JSON.stringify(output) === JSON.stringify(test.expected);
-    results.push({
-      passed,
-      message: test.message,
-      ...(passed
-        ? {}
-        : {
-            error: \`Expected \${JSON.stringify(test.expected)}, but got \${JSON.stringify(output)}\`
-          })
-    });
+  if ("error" in transpiled) {
+    return NextResponse.json({ error: transpiled.error }, { status: 400 });
   }
 
-  myLog("[snippet] All tests completed. Storing final object in __myResult__");
-  globalThis.__myResult__ = { success: true, results };
-} catch (allErr) {
-  myLog("[snippet] Snippet-level error:", String(allErr));
-  globalThis.__myResult__ = { success: false, error: String(allErr) };
-}
-`;
+  const result = await runIsolatedTests({
+    code: transpiled.code,
+    testCases: exercise.testCases,
+  });
 
-    // 7) Compile + run snippet
-    const script = isolate.compileScriptSync(snippet);
-    script.runSync(context); // returns undefined (by design)
-
-    // 8) Extract final object from globalThis.__myResult__
-    const resultRef = jail.getSync("__myResult__");
-    if (!resultRef) {
-      return NextResponse.json(
-        { error: "Snippet did not set final result" },
-        { status: 500 },
-      );
-    }
-
-    // copySync() to get a plain JS object in Node
-    const rawResult = resultRef.copySync() as {
-      success: boolean;
-      results?: unknown;
-      error?: string;
-    };
-
-    if (!rawResult.success) {
-      return NextResponse.json(
-        { error: rawResult.error || "Unknown error occurred" },
-        { status: 500 },
-      );
-    }
-
-    let results: TestResult[];
-    try {
-      results = TestResultSchema.array().parse(rawResult.results);
-    } catch {
-      return NextResponse.json(
-        { error: "Invalid results format" },
-        { status: 500 },
-      );
-    }
-
-    return NextResponse.json({ results }, { status: 200 });
-  } catch (err) {
-    // Outer catch
-    logger.error("[api/exercises/run-tests] Outer catch error:", err);
-    return NextResponse.json({ error: "Failed to run tests" }, { status: 500 });
-  } finally {
-    // 9) Dispose isolate
-    isolate?.dispose();
+  if (!result.success) {
+    return NextResponse.json({ error: result.error }, { status: 500 });
   }
+
+  return NextResponse.json({ results: result.results }, { status: 200 });
 }

--- a/src/features/codingChallenges/lib/runIsolatedTests.ts
+++ b/src/features/codingChallenges/lib/runIsolatedTests.ts
@@ -1,0 +1,134 @@
+import ivm from "isolated-vm";
+import { logger } from "@/lib/logger";
+import {
+  TestCase,
+  TestResult,
+  TestResultSchema,
+} from "@/features/codingChallenges/types";
+
+export type IsolatedTestResult =
+  | { success: true; results: TestResult[] }
+  | { success: false; error: string };
+
+export type RunIsolatedTestsArgs = {
+  code: string;
+  testCases: TestCase[];
+  memoryMb?: number;
+};
+
+export async function runIsolatedTests({
+  code,
+  testCases,
+  memoryMb = Number(process.env.ISOLATE_MEMORY_MB ?? 8),
+}: RunIsolatedTestsArgs): Promise<IsolatedTestResult> {
+  const isolate = new ivm.Isolate({ memoryLimit: memoryMb });
+
+  try {
+    const context = isolate.createContextSync();
+    const jail = context.global;
+    jail.setSync("global", jail.derefInto());
+    jail.setSync(
+      "myLog",
+      new ivm.Callback(
+        (...args: unknown[]) => logger.info("[Isolate log]", ...args),
+        {
+          sync: true,
+        },
+      ),
+    );
+
+    const snippet = buildSnippet(code, testCases);
+    const script = isolate.compileScriptSync(snippet);
+    script.runSync(context);
+
+    const resultRef = jail.getSync("__myResult__");
+    if (!resultRef) {
+      return { success: false, error: "Snippet did not set final result" };
+    }
+
+    const rawResult = resultRef.copySync() as {
+      success: boolean;
+      results?: unknown;
+      error?: string;
+    };
+
+    if (!rawResult.success) {
+      return {
+        success: false,
+        error: rawResult.error ?? "Unknown error occurred",
+      };
+    }
+
+    try {
+      const results = TestResultSchema.array().parse(rawResult.results);
+      return { success: true, results };
+    } catch {
+      return { success: false, error: "Invalid results format" };
+    }
+  } catch (err) {
+    logger.error("[runIsolatedTests] Error:", err);
+    return { success: false, error: "Failed to run snippet" };
+  } finally {
+    isolate.dispose();
+  }
+}
+
+function buildSnippet(code: string, testCases: TestCase[]): string {
+  const codeWithGlobal = `${code}\nif (typeof solve === 'function') globalThis.solve = solve;\n`;
+  const userCodeLiteral = JSON.stringify(codeWithGlobal);
+  const testCasesLiteral = JSON.stringify(testCases).replace(/`/g, "\\`");
+
+  return `
+myLog("[snippet] Starting snippet...");
+
+try {
+  const userCodeString = ${userCodeLiteral};
+  myLog("[snippet] userCodeString length:", userCodeString.length);
+  new Function("globalThis", userCodeString)(globalThis);
+
+  if (typeof globalThis.solve !== "function") {
+    throw new Error("No solve() function found in user code.");
+  }
+
+  const testCases = JSON.parse(\`${testCasesLiteral}\`);
+  const results = [];
+
+  myLog("[snippet] testCases length:", testCases.length);
+
+  for (const [index, test] of testCases.entries()) {
+    myLog("[snippet] Running test #", index + 1, "with input:", test.input);
+    let output;
+    try {
+      output = globalThis.solve(...test.input);
+    } catch (err) {
+      results.push({ passed: false, message: test.message, error: String(err) });
+      continue;
+    }
+
+    if (output === undefined) {
+      results.push({
+        passed: false,
+        message: test.message,
+        error: "Function returned undefined. Make sure you're returning a value.",
+      });
+      continue;
+    }
+
+    const passed = JSON.stringify(output) === JSON.stringify(test.expected);
+    results.push({
+      passed,
+      message: test.message,
+      ...(passed
+        ? {}
+        : { error: \`Expected \${JSON.stringify(test.expected)}, but got \${JSON.stringify(output)}\` }),
+    });
+  }
+
+  myLog("[snippet] All tests completed. Storing final object in __myResult__");
+  globalThis.__myResult__ = { success: true, results };
+} catch (allErr) {
+  myLog("[snippet] Snippet-level error:", String(allErr));
+  globalThis.__myResult__ = { success: false, error: String(allErr) };
+}
+`;
+}

--- a/src/features/codingChallenges/lib/transpile.ts
+++ b/src/features/codingChallenges/lib/transpile.ts
@@ -1,0 +1,31 @@
+import ts from "typescript";
+import { Language } from "@/features/codingChallenges/types";
+
+export const transpile = (
+  code: string,
+  language: Language,
+): { code: string } | { error: string } => {
+  if (language !== "typescript") return { code };
+
+  const result = ts.transpileModule(code, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ESNext,
+      strict: true,
+    },
+    reportDiagnostics: true,
+  });
+
+  if (result.diagnostics?.length) {
+    const messages = result.diagnostics.map((d) => {
+      const msg = ts.flattenDiagnosticMessageText(d.messageText, "\n");
+      const pos = d.file?.getLineAndCharacterOfPosition(d.start ?? 0);
+      const line = (pos?.line ?? 0) + 1;
+      const col = (pos?.character ?? 0) + 1;
+      return `TS Error at ${line}:${col} - ${msg}`;
+    });
+    return { error: messages.join("\n") };
+  }
+
+  return { code: result.outputText };
+};


### PR DESCRIPTION
## Summary
- modularize run-tests API
- add isolated test runner and TypeScript transpiler helpers

## Testing
- `npm run lint`
- `npm test`
