### PR TITLE
Improve clarity with better variable names

### DIFF
--- a/src/components/ui/MarkdownList.tsx
+++ b/src/components/ui/MarkdownList.tsx
@@ -15,4 +15,4 @@ export function MarkdownList({ items }: MarkdownListProps) {
     </ul>
   );
 }
-MarkdownList.displayName = "MarkdownList"; 
+MarkdownList.displayName = "MarkdownList";

--- a/src/components/ui/SectionHeading.tsx
+++ b/src/components/ui/SectionHeading.tsx
@@ -19,4 +19,4 @@ export function SectionHeading({
     </h3>
   );
 }
-SectionHeading.displayName = "SectionHeading"; 
+SectionHeading.displayName = "SectionHeading";

--- a/src/features/codingChallenges/components/tabs/TestCaseAccordion.tsx
+++ b/src/features/codingChallenges/components/tabs/TestCaseAccordion.tsx
@@ -99,4 +99,4 @@ export function TestCaseAccordion({
     </div>
   );
 }
-TestCaseAccordion.displayName = "TestCaseAccordion"; 
+TestCaseAccordion.displayName = "TestCaseAccordion";

--- a/src/features/codingChallenges/hooks/useExerciseState.ts
+++ b/src/features/codingChallenges/hooks/useExerciseState.ts
@@ -8,7 +8,7 @@ export function useExerciseState(exercise: Exercise) {
 
   // React 19 Performance: Memoize computed values to prevent unnecessary re-calculations
   const computedValues = useMemo(() => {
-    const passedTests = testResults.filter((r) => r.passed).length;
+    const passedTests = testResults.filter((result) => result.passed).length;
     const totalTests = exercise.testCases.length;
     const hasRun = testResults.length > 0;
 

--- a/src/features/codingChallenges/hooks/useKeyboardShortcuts.ts
+++ b/src/features/codingChallenges/hooks/useKeyboardShortcuts.ts
@@ -17,22 +17,22 @@ export function useKeyboardShortcuts({
   isFullscreen,
 }: UseKeyboardShortcutsParams) {
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const cmdOrCtrl = e.metaKey || e.ctrlKey;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const cmdOrCtrl = event.metaKey || event.ctrlKey;
 
-      if (cmdOrCtrl && e.key === "Enter") {
-        e.preventDefault();
+      if (cmdOrCtrl && event.key === "Enter") {
+        event.preventDefault();
         runTests();
-      } else if (cmdOrCtrl && e.key === "f") {
-        e.preventDefault();
+      } else if (cmdOrCtrl && event.key === "f") {
+        event.preventDefault();
         toggleFullscreen();
-      } else if (cmdOrCtrl && e.key === "1") {
-        e.preventDefault();
+      } else if (cmdOrCtrl && event.key === "1") {
+        event.preventDefault();
         setActiveTab("instructions");
-      } else if (cmdOrCtrl && e.key === "2") {
-        e.preventDefault();
+      } else if (cmdOrCtrl && event.key === "2") {
+        event.preventDefault();
         setActiveTab("tests");
-      } else if (e.key === "Escape" && isFullscreen) {
+      } else if (event.key === "Escape" && isFullscreen) {
         toggleFullscreen();
       }
     };

--- a/src/features/codingChallenges/lib/runIsolatedTests.ts
+++ b/src/features/codingChallenges/lib/runIsolatedTests.ts
@@ -65,8 +65,8 @@ export async function runIsolatedTests({
     } catch {
       return { success: false, error: "Invalid results format" };
     }
-  } catch (err) {
-    logger.error("[runIsolatedTests] Error:", err);
+  } catch (error) {
+    logger.error("[runIsolatedTests] Error:", error);
     return { success: false, error: "Failed to run snippet" };
   } finally {
     isolate.dispose();
@@ -100,8 +100,8 @@ try {
     let output;
     try {
       output = globalThis.solve(...test.input);
-    } catch (err) {
-      results.push({ passed: false, message: test.message, error: String(err) });
+    } catch (error) {
+      results.push({ passed: false, message: test.message, error: String(error) });
       continue;
     }
 
@@ -126,9 +126,9 @@ try {
 
   myLog("[snippet] All tests completed. Storing final object in __myResult__");
   globalThis.__myResult__ = { success: true, results };
-} catch (allErr) {
-  myLog("[snippet] Snippet-level error:", String(allErr));
-  globalThis.__myResult__ = { success: false, error: String(allErr) };
+} catch (snippetError) {
+  myLog("[snippet] Snippet-level error:", String(snippetError));
+  globalThis.__myResult__ = { success: false, error: String(snippetError) };
 }
 `;
 }

--- a/src/features/codingChallenges/types.ts
+++ b/src/features/codingChallenges/types.ts
@@ -29,11 +29,15 @@ export const CategorySchema = z
     name: CategoryNameSchema,
     method: MethodNameSchema,
   })
-  .superRefine((val, ctx) => {
-    if (!CATEGORY_METHODS[val.name].includes(val.method as never)) {
-      ctx.addIssue({
+  .superRefine((categoryInput, context) => {
+    if (
+      !CATEGORY_METHODS[categoryInput.name].includes(
+        categoryInput.method as never,
+      )
+    ) {
+      context.addIssue({
         code: z.ZodIssueCode.custom,
-        message: `Method ${val.method} is not valid for ${val.name}`,
+        message: `Method ${categoryInput.method} is not valid for ${categoryInput.name}`,
       });
     }
   });


### PR DESCRIPTION
## Summary
- rename callback arguments and error vars for clarity
- tweak typed validation naming
- improve computed state naming
- improve keyboard event param naming
- adjust newline at EOF to satisfy lint

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`