### PR TITLE
add return types for homepage hooks

### DIFF
--- a/src/features/homepage/hooks/useDarkMode.ts
+++ b/src/features/homepage/hooks/useDarkMode.ts
@@ -1,11 +1,16 @@
 import { useEffect, useState } from "react";
 
+export type UseDarkModeReturn = {
+  isDark: boolean;
+  toggleDark: () => void;
+};
+
 /**
  * Custom hook for toggling dark mode
  *
  * Applies or removes the `dark` class on the html element
  */
-export function useDarkMode(defaultDark = true) {
+export function useDarkMode(defaultDark = true): UseDarkModeReturn {
   const [isDark, setIsDark] = useState(defaultDark);
 
   useEffect(() => {

--- a/src/features/homepage/hooks/useLoading.ts
+++ b/src/features/homepage/hooks/useLoading.ts
@@ -1,11 +1,16 @@
 import { useState, useEffect } from "react";
 
+export type UseLoadingReturn = {
+  isLoading: boolean;
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
 /**
  * Custom hook for managing loading state
  *
  * Controls the loading screen duration
  */
-export function useLoading(duration = 1000) {
+export function useLoading(duration = 1000): UseLoadingReturn {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- define return types for `useLoading` and `useDarkMode`
- expose the types via existing hook exports

## Testing
- `npm run type-check`
